### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -7,6 +7,8 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/superzer0/family-app/security/code-scanning/2](https://github.com/superzer0/family-app/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow, either at the top-level (for all jobs), or just at the job level if only one job needs it. Given that most of the job involves read-only operations (checking out code, reading files, caching, uploading artifacts), but the release-asset upload step requires write access to release assets, we should specify the minimal required permissions. The recommended base is `contents: read` for most cases, but for the job that uploads release assets, `contents: write` is required. Make this change above the `jobs:` key (in the root), as there is only one job. If finer-grained permissions are ever needed, you could specify more detailed per-job settings.

Add the following directly above `jobs:` in `.github/workflows/build-artifacts.yml`:
```yaml
permissions:
  contents: write
```
This gives write access to repository contents only (not e.g. Issues or Pull Requests), sufficient for release asset upload and conservative for other steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
